### PR TITLE
Update jquery.webui-popover.js

### DIFF
--- a/dist/jquery.webui-popover.js
+++ b/dist/jquery.webui-popover.js
@@ -345,7 +345,9 @@
 						arrowSize = this.options.arrow?28:0,
 						fixedW = elementW<arrowSize+10?arrowSize:0,
 						fixedH = elementH<arrowSize+10?arrowSize:0;
-						console.log(elementW,arrowSize);
+						if (window.console) {
+							console.log(elementW,arrowSize);
+						}
 					switch (placement) {
 			          case 'bottom':
 			            position = {top: pos.top + pos.height, left: pos.left + pos.width / 2 - targetWidth / 2};


### PR DESCRIPTION
Fix breakage in older versions of IE (e.g., IE9) by not calling console.log unless console is available.
