### PR TITLE
Nudge target fully onto screen if necessary

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -166,6 +166,7 @@
 					placement = this.getPlacement(elementPos);
 					this.initTargetEvents();
 				    var postionInfo = this.getTargetPositin(elementPos,placement,targetWidth,targetHeight);
+					this.moveTargetPositionToWithinViewport(postionInfo.position,$target);
 					this.$target.css(postionInfo.position).addClass(placement).addClass('in');
 
 					if (this.options.type==='iframe'){
@@ -510,6 +511,36 @@
 
 			        }
 			        return {position:position,arrowOffset:arrowOffset};
+				},
+
+				moveTargetPositionToWithinViewport:function(position,target) {
+					// Try to stop the popup from being rendered off the edge
+					// of the display
+					var de = document.documentElement,
+						db = document.body,
+						targetHeight = target.outerHeight(),
+						targetWidth = target.outerWidth(),
+						clientWidth = de.clientWidth,
+						clientHeight = de.clientHeight,
+						topLimit = Math.max( db.scrollTop, de.scrollTop ),
+						leftLimit = Math.max( db.scrollLeft, de.scrollLeft ),
+						bottomLimit = topLimit + clientHeight - targetHeight,
+						rightLimit = leftLimit + clientWidth - targetWidth,
+						positionWasAltered = false;
+					if( position.left < leftLimit ||
+						rightLimit < position.left ||
+						position.top < topLimit ||
+						bottomLimit < position.top ) {
+						alteredPosition = true;
+						// Ordering to favor placing the target in the top left
+						// corner on very small viewports
+						position.top = Math.min( position.top, bottomLimit );
+						position.left = Math.min( position.left, rightLimit );
+						position.top = Math.max( position.top, topLimit );
+						position.left = Math.max( position.left, leftLimit );
+					}
+					// TODO: Fix the arrow when the position changes
+					return positionWasAltered;
 				}
 		};
 		$.fn[ pluginName ] = function ( options ) {


### PR DESCRIPTION
I had to fix an issue very similar to https://github.com/sandywalker/webui-popover/issues/21 and wanted to pass it upstream in case it was useful.

Looking at the rest of the codebase, you'll probably want to add an option to enable this behaviour.

It would also be nice to add handling for the arrow.  It's fine for issue where the long string means there's not really a bad position, but a small screen could easily cause the arrow to point somewhere strange.

It might also be nice to properly handle margins beyond just using outerWidth.  (E.g.  In the case of the bug, it would be nice to add the margin because there's plenty of space, but as screens get small, it would be more important to get as much of the popup on-screen as possible).

I can't make promises, but I might be able to incorporate suggestions into the PR

