### PR TITLE
allow title: to take a function

### DIFF
--- a/dist/jquery.webui-popover.js
+++ b/dist/jquery.webui-popover.js
@@ -286,7 +286,7 @@
 							title = this.options.title;
 						}
 
-            $titleEl.html(title);
+						$titleEl.html(title);
 					}else{
 						$titleEl.remove();
 					}

--- a/dist/jquery.webui-popover.js
+++ b/dist/jquery.webui-popover.js
@@ -280,7 +280,13 @@
 				setTitle:function(title){
 					var $titleEl = this.getTitleElement();
 					if (title){
-						$titleEl.html(title);
+						if ($.isFunction(this.options.title)){
+							title = this.options.title.apply(this.$element[0],arguments);
+						}else{
+							title = this.options.title;
+						}
+
+            $titleEl.html(title);
 					}else{
 						$titleEl.remove();
 					}


### PR DESCRIPTION
I needed to dynamically set the title.  I have several popups on my page and both title and content came from some DOM element. Something like this:

```
  $('#my-element > .text').webuiPopover({
    trigger: 'hover',
    type: 'html',
    width: 550,
    placement: 'auto',
    title: function() {
      var id = $(this).attr('href');
      return $(document).find('#data > li#' + id + ' > .title').html();
    },
    content: function() {
      var id = $(this).attr('href');
      return $(document).find('#data > li#' + id + ' > .description').html();
    }
  });
```

Hopefully someone else might find this useful