### PR TITLE
Allow bower install to work with jquery 2 also

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "dist/jquery.webui-popover.js"
   ],
   "dependencies": {
-      "jquery": "^1.7.0"
+      "jquery": ">=1.7.0"
   },
   "homepage":"https://github.com/sandywalker/webui-popover"
 }


### PR DESCRIPTION
Changes the jquery dependency from `^1.7.0` to `>=1.7.0`. Will allow bower to install without complaint where a 2.* version of jquery is already available.