### PR TITLE
Example of dismissible option working with manual trigger

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -451,7 +451,7 @@
             }
         },
         bodyClickHandler: function() {
-            if (this.getTrigger() === 'click') {
+            if (this.getTrigger() === 'click' || (this.getTrigger() === 'manual' && this.options.dismissible)) {
                 if (this._targetclick) {
                     this._targetclick = false;
                 } else {


### PR DESCRIPTION
The addition of the dismissible option is a great feature, but currently it only works when the trigger is click ... regardless of it the dismissible option is passed as an option for any other trigger.

It would be a nice addition, if when the dismissible option is explicitly set to true and passed as an option, for it to be adhered when the trigger was set to manual. It would save the effort of having to write custom hide logic. And from my understanding, the click events are being set on the body regardless. 