### PR TITLE
Fix popover not hiding and no backdrop in async mode

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -187,8 +187,6 @@
                     this.setContent(this.getContent());
                 } else {
                     this.setContentASync(this.options.content);
-                    this.displayContent();
-                    return;
                 }
                 $target.show();
             }


### PR DESCRIPTION
Because of the return statement this._opened is never set to true so the popover is not registered 'open' in the popover list. The effect is the hide method cannot hide it because this._opened is always false in async mode.