### PR TITLE
Adding "webui-" prefix to arrow CSS class.

### DIFF
--- a/src/jquery.webui-popover.css
+++ b/src/jquery.webui-popover.css
@@ -147,8 +147,8 @@
 .webui-no-padding .list-group-item:last-child {
   border-bottom: 0;
 }
-.webui-popover > .arrow,
-.webui-popover > .arrow:after {
+.webui-popover > .webui-arrow,
+.webui-popover > .webui-arrow:after {
   position: absolute;
   display: block;
   width: 0;
@@ -156,16 +156,16 @@
   border-color: transparent;
   border-style: solid;
 }
-.webui-popover > .arrow {
+.webui-popover > .webui-arrow {
   border-width: 11px;
 }
-.webui-popover > .arrow:after {
+.webui-popover > .webui-arrow:after {
   border-width: 10px;
   content: "";
 }
-.webui-popover.top > .arrow,
-.webui-popover.top-right > .arrow,
-.webui-popover.top-left > .arrow {
+.webui-popover.top > .webui-arrow,
+.webui-popover.top-right > .webui-arrow,
+.webui-popover.top-left > .webui-arrow {
   bottom: -11px;
   left: 50%;
   margin-left: -11px;
@@ -173,18 +173,18 @@
   border-top-color: rgba(0, 0, 0, 0.25);
   border-bottom-width: 0;
 }
-.webui-popover.top > .arrow:after,
-.webui-popover.top-right > .arrow:after,
-.webui-popover.top-left > .arrow:after {
+.webui-popover.top > .webui-arrow:after,
+.webui-popover.top-right > .webui-arrow:after,
+.webui-popover.top-left > .webui-arrow:after {
   content: " ";
   bottom: 1px;
   margin-left: -10px;
   border-top-color: #ffffff;
   border-bottom-width: 0;
 }
-.webui-popover.right > .arrow,
-.webui-popover.right-top > .arrow,
-.webui-popover.right-bottom > .arrow {
+.webui-popover.right > .webui-arrow,
+.webui-popover.right-top > .webui-arrow,
+.webui-popover.right-bottom > .webui-arrow {
   top: 50%;
   left: -11px;
   margin-top: -11px;
@@ -192,18 +192,18 @@
   border-right-color: #999999;
   border-right-color: rgba(0, 0, 0, 0.25);
 }
-.webui-popover.right > .arrow:after,
-.webui-popover.right-top > .arrow:after,
-.webui-popover.right-bottom > .arrow:after {
+.webui-popover.right > .webui-arrow:after,
+.webui-popover.right-top > .webui-arrow:after,
+.webui-popover.right-bottom > .webui-arrow:after {
   content: " ";
   left: 1px;
   bottom: -10px;
   border-left-width: 0;
   border-right-color: #ffffff;
 }
-.webui-popover.bottom > .arrow,
-.webui-popover.bottom-right > .arrow,
-.webui-popover.bottom-left > .arrow {
+.webui-popover.bottom > .webui-arrow,
+.webui-popover.bottom-right > .webui-arrow,
+.webui-popover.bottom-left > .webui-arrow {
   top: -11px;
   left: 50%;
   margin-left: -11px;
@@ -211,18 +211,18 @@
   border-bottom-color: rgba(0, 0, 0, 0.25);
   border-top-width: 0;
 }
-.webui-popover.bottom > .arrow:after,
-.webui-popover.bottom-right > .arrow:after,
-.webui-popover.bottom-left > .arrow:after {
+.webui-popover.bottom > .webui-arrow:after,
+.webui-popover.bottom-right > .webui-arrow:after,
+.webui-popover.bottom-left > .webui-arrow:after {
   content: " ";
   top: 1px;
   margin-left: -10px;
   border-bottom-color: #ffffff;
   border-top-width: 0;
 }
-.webui-popover.left > .arrow,
-.webui-popover.left-top > .arrow,
-.webui-popover.left-bottom > .arrow {
+.webui-popover.left > .webui-arrow,
+.webui-popover.left-top > .webui-arrow,
+.webui-popover.left-bottom > .webui-arrow {
   top: 50%;
   right: -11px;
   margin-top: -11px;
@@ -230,45 +230,45 @@
   border-left-color: #999999;
   border-left-color: rgba(0, 0, 0, 0.25);
 }
-.webui-popover.left > .arrow:after,
-.webui-popover.left-top > .arrow:after,
-.webui-popover.left-bottom > .arrow:after {
+.webui-popover.left > .webui-arrow:after,
+.webui-popover.left-top > .webui-arrow:after,
+.webui-popover.left-bottom > .webui-arrow:after {
   content: " ";
   right: 1px;
   border-right-width: 0;
   border-left-color: #ffffff;
   bottom: -10px;
 }
-.webui-popover-inverse.top > .arrow,
-.webui-popover-inverse.top-left > .arrow,
-.webui-popover-inverse.top-right > .arrow,
-.webui-popover-inverse.top > .arrow:after,
-.webui-popover-inverse.top-left > .arrow:after,
-.webui-popover-inverse.top-right > .arrow:after {
+.webui-popover-inverse.top > .webui-arrow,
+.webui-popover-inverse.top-left > .webui-arrow,
+.webui-popover-inverse.top-right > .webui-arrow,
+.webui-popover-inverse.top > .webui-arrow:after,
+.webui-popover-inverse.top-left > .webui-arrow:after,
+.webui-popover-inverse.top-right > .webui-arrow:after {
   border-top-color: #333333;
 }
-.webui-popover-inverse.right > .arrow,
-.webui-popover-inverse.right-top > .arrow,
-.webui-popover-inverse.right-bottom > .arrow,
-.webui-popover-inverse.right > .arrow:after,
-.webui-popover-inverse.right-top > .arrow:after,
-.webui-popover-inverse.right-bottom > .arrow:after {
+.webui-popover-inverse.right > .webui-arrow,
+.webui-popover-inverse.right-top > .webui-arrow,
+.webui-popover-inverse.right-bottom > .webui-arrow,
+.webui-popover-inverse.right > .webui-arrow:after,
+.webui-popover-inverse.right-top > .webui-arrow:after,
+.webui-popover-inverse.right-bottom > .webui-arrow:after {
   border-right-color: #333333;
 }
-.webui-popover-inverse.bottom > .arrow,
-.webui-popover-inverse.bottom-left > .arrow,
-.webui-popover-inverse.bottom-right > .arrow,
-.webui-popover-inverse.bottom > .arrow:after,
-.webui-popover-inverse.bottom-left > .arrow:after,
-.webui-popover-inverse.bottom-right > .arrow:after {
+.webui-popover-inverse.bottom > .webui-arrow,
+.webui-popover-inverse.bottom-left > .webui-arrow,
+.webui-popover-inverse.bottom-right > .webui-arrow,
+.webui-popover-inverse.bottom > .webui-arrow:after,
+.webui-popover-inverse.bottom-left > .webui-arrow:after,
+.webui-popover-inverse.bottom-right > .webui-arrow:after {
   border-bottom-color: #333333;
 }
-.webui-popover-inverse.left > .arrow,
-.webui-popover-inverse.left-top > .arrow,
-.webui-popover-inverse.left-bottom > .arrow,
-.webui-popover-inverse.left > .arrow:after,
-.webui-popover-inverse.left-top > .arrow:after,
-.webui-popover-inverse.left-bottom > .arrow:after {
+.webui-popover-inverse.left > .webui-arrow,
+.webui-popover-inverse.left-top > .webui-arrow,
+.webui-popover-inverse.left-bottom > .webui-arrow,
+.webui-popover-inverse.left > .webui-arrow:after,
+.webui-popover-inverse.left-top > .webui-arrow:after,
+.webui-popover-inverse.left-bottom > .webui-arrow:after {
   border-left-color: #333333;
 }
 .webui-popover i.icon-refresh:before {

--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -32,7 +32,7 @@
         type: 'html',
         animation: null,
         template: '<div class="webui-popover">' +
-            '<div class="arrow"></div>' +
+            '<div class="webui-arrow"></div>' +
             '<div class="webui-popover-inner">' +
             '<a href="#" class="close"></a>' +
             '<h3 class="webui-popover-title"></h3>' +
@@ -325,7 +325,7 @@
 
             //init the popover and insert into the document body
             if (!this.options.arrow) {
-                $target.find('.arrow').remove();
+                $target.find('.webui-arrow').remove();
             }
             $target.detach().css({
                 top: _offsetOut,
@@ -384,7 +384,7 @@
                 });
             }
             if (this.options.arrow) {
-                var $arrow = this.$target.find('.arrow');
+                var $arrow = this.$target.find('.webui-arrow');
                 $arrow.removeAttr('style');
 
                 //prevent arrow change by content size

--- a/src/jquery.webui-popover.less
+++ b/src/jquery.webui-popover.less
@@ -210,7 +210,7 @@
 }
 
 
-.webui-popover > .arrow{
+.webui-popover > .webui-arrow{
   &,&:after{
 		position: absolute;
 		display: block;
@@ -221,18 +221,18 @@
   }	
 }
 
-.webui-popover > .arrow {
+.webui-popover > .webui-arrow {
   border-width: @popover-arrow-outer-width;
 }
-.webui-popover > .arrow:after {
+.webui-popover > .webui-arrow:after {
   border-width: @popover-arrow-width;
   content: "";
 }
 
 .webui-popover{
-  &.top >.arrow,
-  &.top-right >.arrow,
-  &.top-left >.arrow
+  &.top >.webui-arrow,
+  &.top-right >.webui-arrow,
+  &.top-left >.webui-arrow
   {
  	  bottom: -@popover-arrow-outer-width;
 	  left: 50%;
@@ -248,9 +248,9 @@
 		  border-bottom-width: 0;
 	  }
   }
-  &.right > .arrow,
-  &.right-top > .arrow,
-  &.right-bottom > .arrow {
+  &.right > .webui-arrow,
+  &.right-top > .webui-arrow,
+  &.right-bottom > .webui-arrow {
     top: 50%;
     left: -@popover-arrow-outer-width;
     margin-top: -@popover-arrow-outer-width;
@@ -265,9 +265,9 @@
       border-right-color: @popover-arrow-color;
     }
   }
-  &.bottom >.arrow,
-  &.bottom-right >.arrow,
-  &.bottom-left >.arrow
+  &.bottom >.webui-arrow,
+  &.bottom-right >.webui-arrow,
+  &.bottom-left >.webui-arrow
   {
  	  top: -@popover-arrow-outer-width;
 	  left: 50%;
@@ -283,9 +283,9 @@
 		  border-top-width: 0;
 	  }
   }
-  &.left > .arrow,
-  &.left-top > .arrow,
-  &.left-bottom > .arrow {
+  &.left > .webui-arrow,
+  &.left-top > .webui-arrow,
+  &.left-bottom > .webui-arrow {
     top: 50%;
     right: -@popover-arrow-outer-width;
     margin-top: -@popover-arrow-outer-width;
@@ -303,30 +303,30 @@
 }
 
 .webui-popover-inverse{
-	&.top > .arrow,
-	&.top-left > .arrow,
-	&.top-right > .arrow{
+	&.top > .webui-arrow,
+	&.top-left > .webui-arrow,
+	&.top-right > .webui-arrow{
 		&,&:after{
 			border-top-color: @popover-inverse-bg;
 		}
 	}
-	&.right > .arrow,
-  &.right-top > .arrow,
-  &.right-bottom > .arrow{
+	&.right > .webui-arrow,
+  &.right-top > .webui-arrow,
+  &.right-bottom > .webui-arrow{
 		&,&:after{
 			border-right-color: @popover-inverse-bg;	
 		}
 	}
-	&.bottom > .arrow,
-	&.bottom-left > .arrow,
-	&.bottom-right > .arrow{
+	&.bottom > .webui-arrow,
+	&.bottom-left > .webui-arrow,
+	&.bottom-right > .webui-arrow{
 		&,&:after{
 			border-bottom-color: @popover-inverse-bg;	
 		}
 	}
-	&.left > .arrow,
-  &.left-top > .arrow,
-  &.left-bottom > .arrow{
+	&.left > .webui-arrow,
+  &.left-top > .webui-arrow,
+  &.left-bottom > .webui-arrow{
 		&,&:after{
 			border-left-color: @popover-inverse-bg;	
 		}


### PR DESCRIPTION
Wordpress also uses the class `.arrow`, including the :after element, which is painful to reconcile. Adding this prefix makes the class unique, and more in line with the other elements inside the popover.