### PR TITLE
Added hideEmpty option.

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -69,7 +69,8 @@
                 onload: '',
                 height: '',
                 width: ''
-            }
+            },
+            hideEmpty: false
         };
 
         var rtlClass = pluginClass + '-rtl';
@@ -283,11 +284,19 @@
                     if (!this.options.closeable) {
                         $target.find('.close').off('click').remove();
                     }
-                    if (!this.isAsync()) {
+
+                    var isAsync = this.isAsync();
+                    if (!isAsync) {
                         this.setContent(this.getContent());
                     } else {
                         this.setContentASync(this.options.content);
                     }
+
+                    // todo: Add support for async hideEmpty option.
+                    if (!isAsync && this.options.hideEmpty && this.content === '') {
+                        return;
+                    }
+
                     $target.show();
                 }
 

--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -293,7 +293,7 @@
                     }
 
                     // todo: Add support for async hideEmpty option.
-                    if (!isAsync && this.options.hideEmpty && this.content === '') {
+                    if (this.canEmptyHide() && this.content === '') {
                         return;
                     }
 
@@ -328,6 +328,15 @@
                     //placement
                     placement = 'bottom',
                     e = $.Event('show.' + pluginType);
+
+                if (this.canEmptyHide()) {
+
+                    var content = $targetContent.children().html();
+                    if (content !== null && content.trim().length === 0) {
+                        return;
+                    }
+                }
+
                 //if (this.hasContent()){
                 this.$element.trigger(e, [$target]);
                 //}
@@ -548,7 +557,10 @@
             hasContent: function() {
                 return this.getContent();
             },
-            getIframe: function() {
+            canEmptyHide: function () {
+                return this.options.hideEmpty && this.options.type === "html";
+            },
+            getIframe: function () {
                 var $iframe = $('<iframe></iframe>').attr('src', this.getUrl());
                 var self = this;
                 $.each(this._defaults.iframeOptions, function(opt) {

--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -285,14 +285,12 @@
                         $target.find('.close').off('click').remove();
                     }
 
-                    var isAsync = this.isAsync();
-                    if (!isAsync) {
+                    if (!this.isAsync()) {
                         this.setContent(this.getContent());
                     } else {
                         this.setContentASync(this.options.content);
                     }
 
-                    // todo: Add support for async hideEmpty option.
                     if (this.canEmptyHide() && this.content === '') {
                         return;
                     }


### PR DESCRIPTION
Hi I added support for a hideEmpty option.
It does only support pop-type "html" but I believe it's good enough for most cases.

I find this feature very useful with frameworks where you bind the data-content-value or html
and it can sometimes be empty and you don't want the pop to be displayed.

I have tested it with all the dev-demo pops and it works very well. 
Hope this feature can make it into the master-branch soon. 

// Mike


