### PR TITLE
Disable event listeners for manual triggering

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -555,10 +555,10 @@
             hasContent: function() {
                 return this.getContent();
             },
-            canEmptyHide: function () {
-                return this.options.hideEmpty && this.options.type === "html";
+            canEmptyHide: function() {
+                return this.options.hideEmpty && this.options.type === 'html';
             },
-            getIframe: function () {
+            getIframe: function() {
                 var $iframe = $('<iframe></iframe>').attr('src', this.getUrl());
                 var self = this;
                 $.each(this._defaults.iframeOptions, function(opt) {

--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -150,14 +150,16 @@
         WebuiPopover.prototype = {
             //init webui popover
             init: function() {
-                //init the event handlers
-                if (this.getTrigger() === 'click' || isMobile) {
-                    this.$element.off('click touchend').on('click touchend', $.proxy(this.toggle, this));
-                } else if (this.getTrigger() === 'hover') {
-                    this.$element
-                        .off('mouseenter mouseleave click')
-                        .on('mouseenter', $.proxy(this.mouseenterHandler, this))
-                        .on('mouseleave', $.proxy(this.mouseleaveHandler, this));
+                if (this.getTrigger() !== 'manual') {
+                    //init the event handlers
+                    if (this.getTrigger() === 'click' || isMobile) {
+                        this.$element.off('click touchend').on('click touchend', $.proxy(this.toggle, this));
+                    } else if (this.getTrigger() === 'hover') {
+                        this.$element
+                            .off('mouseenter mouseleave click')
+                            .on('mouseenter', $.proxy(this.mouseenterHandler, this))
+                            .on('mouseleave', $.proxy(this.mouseleaveHandler, this));
+                    }
                 }
                 this._poped = false;
                 this._inited = true;


### PR DESCRIPTION
See #178

If the option `trigger: 'manual'` is set, no events should be listened to by default.