### PR TITLE
Update jquery.webui-popover.js

### DIFF
--- a/dist/jquery.webui-popover.js
+++ b/dist/jquery.webui-popover.js
@@ -265,12 +265,6 @@
                 if (this.$target) {
                     this.$target.removeClass('in').addClass(this.getHideAnimation());
                     var that = this;
-                    setTimeout(function() {
-                        that.$target.hide();
-                        if (!that.getCache()) {
-                            that.$target.remove();
-                        }
-                    }, that.getHideDelay());
                 }
                 if (this.options.backdrop) {
                     backdrop.hide();


### PR DESCRIPTION
Hi, thanks for your plugin. I'm using it for a project and so far so good. But I need a functionality that you do not provide. When a popover is open, if you resize the windows, the popup doesn't stick to it's relative position and remains sort of fixed where it was before.

What I ended up doing to prevent this behaviour was to hide and reopen the popover on resizes events. But for some reason I don't quite understand the hide functionality has a timeout, making the popup to hide quickly after his reopening.

I looked into your code and deleted those lines, that seems to end the hide timeout, and now I can resize my window and the behaviour is the one I want.

I understand that piece of code may be important, or even crucial, so I make this pull request so you can look into it, and decide if it can be removed, refactored, or toggled via a new attribute or something.

Thank you very much.

Pablo.