### PR TITLE
popover content callback support

### DIFF
--- a/dist/jquery.webui-popover.js
+++ b/dist/jquery.webui-popover.js
@@ -1,5 +1,5 @@
 /*
- *  webui popover plugin  - v1.2.16
+ *  webui popover plugin  - v1.2.17
  *  A lightWeight popover plugin with jquery ,enchance the  popover plugin of bootstrap with some awesome new features. It works well with bootstrap ,but bootstrap is not necessary!
  *  https://github.com/sandywalker/webui-popover
  *
@@ -685,6 +685,8 @@
                     } else {
                         content.removeClass(pluginClass + '-content').appendTo($ct);
                     }
+                } else if (typeof content === 'function') {
+                    content($ct);
                 }
                 this.$target = $target;
             },


### PR DESCRIPTION
Hi

Because all react popover packages I found are quite underdeveloped, after taking a closer look at this nice popover package I found a simple way to use it with React. Of course one should have jquery loaded already 

Allowing a callback function as 'content' property of popover constructor gives us a simple way of using this package with react projects. E.g. :

```

class PopoverContent extends React.Component {
  render() {
    return (
      <div>test popover content</div>
    );
  }
}

class ClickMeToPop extends React.Component {
  popover = (instance) => {
    let self = this;

    $(instance).webuiPopover({
      cache: false, //important because DOM changes all the time in React
      title: 'title',
      content: function (ct) {
        ReactDOM.render(
          <PopoverContent context={ct} testProp={self.state.test}/>,
          ct.$target.find('.webui-popover-content').get(0) //ugly way :-(
        );
      }
    })
  }

  render() {
    return (
      <div ref={this.popover}>Click to pop</div>
    );
  }
}
```