### PR TITLE
Fix for dismissible option breaking with multiple popovers open

### DIFF
--- a/demo/test-issue248.html
+++ b/demo/test-issue248.html
@@ -10,7 +10,7 @@
   <script src="../src/jquery.webui-popover.js" ></script>
 
   <style type="text/css">
-      #popover1 {
+      #popover1, #popover3 {
         margin-left: 50px;
         margin-right: 100px;
       }
@@ -38,12 +38,25 @@
             placement: "bottom",
             content: "I'm dismissible"
         });
+
+        $("#popover3").webuiPopover({
+            multi: true,
+            dismissible: true,
+            placement: "bottom",
+            content: "I'm popover 3"
+        });
+        $("#popover4").webuiPopover({
+            multi: true,
+            dismissible: true,
+            placement: "bottom",
+            content: "I'm popover 4"
+        });
     });
   </script>
 </head>
 <body>
     <div class="desc">
-        <b>Problem</b>: Opening a dismissible popover causes non-dismissible popovers to become dismissible.<br /><br />
+        <b>Problem of issue#248</b>: Opening a dismissible popover causes non-dismissible popovers to become dismissible.<br /><br />
 
         <b>Initial conditions</b>: Popover 1 is not dismissible. Popover 2 is dismissible.<br /><br />
 
@@ -54,6 +67,20 @@
     <div class="popContainer">
         <div id="popover1" class="pop">Popover 1</div>
         <div id="popover2" class="pop">Popover 2</div>
+    </div>
+
+    <div class="desc">
+        <b>With issue#248 solution in place, ensure that</b>: When an outside click is done for two open popovers, 
+        both should dismiss themselves through their own bodyClickHandler individually.<br /><br />
+
+        <b>Initial conditions</b>: Both popovers are dismissible and have multi:true.<br /><br />
+
+        Step 1) Open Popover 3 and Popover 4 so that they're both open at the same time.<br />
+        Step 2) Click outside of both of them. Make sure both close.<br />
+    </div>
+    <div>
+        <div id="popover3" class="pop">Popover 3</div>
+        <div id="popover4" class="pop">Popover 4</div>
     </div>
 </body>
 </html>

--- a/demo/test-issue248.html
+++ b/demo/test-issue248.html
@@ -10,7 +10,7 @@
   <script src="../src/jquery.webui-popover.js" ></script>
 
   <style type="text/css">
-      #popover1, #popover3 {
+      #popover1 {
         margin-left: 50px;
         margin-right: 100px;
       }
@@ -38,19 +38,6 @@
             placement: "bottom",
             content: "I'm dismissible"
         });
-
-        $("#popover3").webuiPopover({
-            multi: true,
-            dismissible: true,
-            placement: "bottom",
-            content: "I'm popover 3"
-        });
-        $("#popover4").webuiPopover({
-            multi: true,
-            dismissible: true,
-            placement: "bottom",
-            content: "I'm popover 4"
-        });
     });
   </script>
 </head>
@@ -68,20 +55,5 @@
         <div id="popover1" class="pop">Popover 1</div>
         <div id="popover2" class="pop">Popover 2</div>
     </div>
-
-    <div class="desc">
-        <b>Problem</b>: When an outside click is done for two open popovers, 
-        both should dismiss themselves through their own bodyClickHandler individually.<br /><br />
-
-        <b>Initial conditions</b>: Both popovers are dismissible and have multi:true.<br /><br />
-
-        Step 1) Open Popover 3 and Popover 4 so that they're both open at the same time.<br />
-        Step 2) Click outside of both of them. Observe that only one closes!<br />
-    </div>
-    <div>
-        <div id="popover3" class="pop">Popover 3</div>
-        <div id="popover4" class="pop">Popover 4</div>
-    </div>
-
 </body>
 </html>

--- a/demo/test-issue248.html
+++ b/demo/test-issue248.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html>
+<head>
+  <title>Issue (#248) - Dismissible option not working with multiple popovers</title>
+  
+  <link rel="stylesheet" href="../src/jquery.webui-popover.css" />
+  <script src="jquery.js" ></script>
+  <script src="bootstrap.js" ></script>
+  <script src="../src/jquery.webui-popover.js" ></script>
+
+  <style type="text/css">
+      #popover1, #popover3 {
+        margin-left: 50px;
+        margin-right: 100px;
+      }
+      .pop {
+          display: inline-block;
+          border: 1px solid silver;
+          padding: 2px;
+      }
+      .popContainer {
+        margin-bottom: 60px;
+      }
+      .desc {
+        margin-bottom: 20px;
+      }
+  </style>
+  <script type="text/javascript">
+    $(document).ready(function() {
+        $("#popover1").webuiPopover({
+            dismissible: false,
+            placement: "bottom",
+            content: "I'm not dismissible"
+        });
+        $("#popover2").webuiPopover({
+            dismissible: true,
+            placement: "bottom",
+            content: "I'm dismissible"
+        });
+
+        $("#popover3").webuiPopover({
+            multi: true,
+            dismissible: true,
+            placement: "bottom",
+            content: "I'm popover 3"
+        });
+        $("#popover4").webuiPopover({
+            multi: true,
+            dismissible: true,
+            placement: "bottom",
+            content: "I'm popover 4"
+        });
+    });
+  </script>
+</head>
+<body>
+    <div class="desc">
+        <b>Problem</b>: Opening a dismissible popover causes non-dismissible popovers to become dismissible.<br /><br />
+
+        <b>Initial conditions</b>: Popover 1 is not dismissible. Popover 2 is dismissible.<br /><br />
+
+        Step 1) Click popover 1. Observe that it is not dismissible. Close it.<br />
+        Step 2) Click popover 2. Observe that it is dismissible. Close it.<br />
+        Step 3) Click popover 1. Observe that it is now dismissible!<br />
+    </div>
+    <div class="popContainer">
+        <div id="popover1" class="pop">Popover 1</div>
+        <div id="popover2" class="pop">Popover 2</div>
+    </div>
+
+    <div class="desc">
+        <b>Problem</b>: When an outside click is done for two open popovers, 
+        both should dismiss themselves through their own bodyClickHandler individually.<br /><br />
+
+        <b>Initial conditions</b>: Both popovers are dismissible and have multi:true.<br /><br />
+
+        Step 1) Open Popover 3 and Popover 4 so that they're both open at the same time.<br />
+        Step 2) Click outside of both of them. Observe that only one closes!<br />
+    </div>
+    <div>
+        <div id="popover3" class="pop">Popover 3</div>
+        <div id="popover4" class="pop">Popover 4</div>
+    </div>
+
+</body>
+</html>

--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -78,7 +78,6 @@
         var _srcElements = [];
         var backdrop = $('<div class="webui-popover-backdrop"></div>');
         var _globalIdSeed = 0;
-        var _isBodyEventHandled = false;
         var _offsetOut = -2000; // the value offset  out of the screen
         var $document = $(document);
 
@@ -727,19 +726,18 @@
             },
 
             bindBodyEvents: function() {
-                if (_isBodyEventHandled) {
-                    return;
-                }
                 if (this.options.dismissible && this.getTrigger() === 'click') {
                     if (isMobile) {
                         $document.off('touchstart.webui-popover').on('touchstart.webui-popover', $.proxy(this.bodyTouchStartHandler, this));
                     } else {
-                        $document.off('keyup.webui-popover').on('keyup.webui-popover', $.proxy(this.escapeHandler, this));
-                        $document.off('click.webui-popover').on('click.webui-popover', $.proxy(this.bodyClickHandler, this));
+                        $document.off('keyup.webui-popover' + this._idSeed)
+                            .on('keyup.webui-popover' + this._idSeed, $.proxy(this.escapeHandler, this));
+                        $document.off('click.webui-popover' + this._idSeed)
+                            .on('click.webui-popover' + this._idSeed, $.proxy(this.bodyClickHandler, this));
                     }
                 } else if (this.getTrigger() === 'hover') {
-                    $document.off('touchend.webui-popover')
-                        .on('touchend.webui-popover', $.proxy(this.bodyClickHandler, this));
+                    $document.off('touchend.webui-popover' + this._idSeed)
+                        .on('touchend.webui-popover' + this._idSeed, $.proxy(this.bodyClickHandler, this));
                 }
             },
 
@@ -770,7 +768,7 @@
             },
             escapeHandler: function(e) {
                 if (e.keyCode === 27) {
-                    this.hideAll();
+                    this.hide();
                 }
             },
             bodyTouchStartHandler: function(e) {
@@ -785,7 +783,6 @@
                 });
             },
             bodyClickHandler: function(e) {
-                _isBodyEventHandled = true;
                 var canHide = true;
                 for (var i = 0; i < _srcElements.length; i++) {
                     var pop = getPopFromElement(_srcElements[i]);
@@ -804,7 +801,7 @@
                     }
                 }
                 if (canHide) {
-                    hideAllPop();
+                    this.hide();
                 }
             },
 


### PR DESCRIPTION
I've been working on an app where many popovers are present, using a mix of multi:true and dismissible:false and have run into issues where the dismissible option seems to not be functioning correctly. 

Problem: Opening a dismissible popover along with a non-dimissible popover can cause the non-dismissible popover to become dismissible! This is because when we have the non-dismissible popover open and click outside of it, the "bodyClickHandler" runs for the dismissible popover and calls hideAllPop() inside of it! We would prefer that it only calls this.hide() to only hide itself, not other non-dismissible popovers.

So, we have now made it so popovers can only dismiss themselves. I think this makes sense as a dismissible popover should not be able to tell a non-dismissible popover to close (unless multi:false).

However, this reveals a pre-existing issue in that not all bodyClickHandlers are running for every popover. If we click outside of two dismissible popovers, only one will close, showing that not all are running. This is because "click.webui-popover" is not a unique event. To make it unique, we append this._idSeed. Now, each popover has its own bodyClickHandler in which it can close itself if the right conditions occur.

Please see demo/test-issue248.html which I've created and make sure we're running the version of web-uipopover before these changes! It will walk you through these issues and demonstrate why these fixes are necessary. 
