### PR TITLE
Modify getElementPosition for position absolute

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -945,7 +945,7 @@
                         height: this.$element[0].offsetHeight || elRect.height
                     });
                     // Else fixed container need recalculate the  position
-                } else if (cssPos === 'fixed') {
+                } else if (cssPos === 'fixed' || cssPos === 'absolute') {
                     var containerRect = container[0].getBoundingClientRect();
                     return {
                         top: elRect.top - containerRect.top + container.scrollTop(),


### PR DESCRIPTION
Modifying the position: fixed check of getElementPosition to also check for absolute seems to fix https://github.com/sandywalker/webui-popover/issues/224