### PR TITLE
Update jquery.webui-popover.js

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -833,6 +833,8 @@
                     container = this.options.container,
                     clientWidth = container.innerWidth(),
                     clientHeight = container.innerHeight(),
+                    windowHeight = $(window).height(),
+                    windowScrollHeight = $(window).scrollTop(),
                     scrollTop = container.scrollTop(),
                     scrollLeft = container.scrollLeft(),
                     pageX = Math.max(0, pos.left - scrollLeft),
@@ -896,6 +898,13 @@
                             }
                         } else {
                             placement = isH ? 'left-top' : 'top-left';
+                        }
+                    }
+                    if(isV) {
+                        if( (pos.top - windowScrollHeight) > windowHeight/3*2 ) {
+                            placement = placement.replace('bottom','top');
+                        } else {
+                            placement = placement.replace('top','bottom');
                         }
                     }
                 } else if (placement === 'auto-top') {


### PR DESCRIPTION
Update vertical behavior.
Example in image.

If element is under viewport, popover will shown on top of element.

with **placement** : "vertical" option 
<img width="737" alt="screenshot 2018-02-08 17 30 54" src="https://user-images.githubusercontent.com/1709390/35970848-0b6e06f2-0cf6-11e8-8ddb-464c7cc9216d.png">
